### PR TITLE
Tweak.xm - https

### DIFF
--- a/Tweak.xm
+++ b/Tweak.xm
@@ -60,7 +60,7 @@ static inline unsigned char FPWListenerName(NSString *listenerName) {
         //PARSE URL
         subreddit = [subreddit stringByReplacingOccurrencesOfString:@" " withString:@""];
         NSLog(@"[%@] Subreddit: %@", tweakName, subreddit);
-        NSURL *blogURL = [NSURL URLWithString:[NSString stringWithFormat:@"http://www.reddit.com%@.json", subreddit]];
+        NSURL *blogURL = [NSURL URLWithString:[NSString stringWithFormat:@"https://www.reddit.com%@.json", subreddit]];
         NSError *jsonDataError = nil;
         NSData *jsonData = [NSURLConnection sendSynchronousRequest:[NSURLRequest requestWithURL:blogURL] returningResponse:nil error:&jsonDataError];
         if (jsonDataError) {


### PR DESCRIPTION
Uses https rather than http to pull in the json file. Reddit supports full site-wide https now, including for those json files, but doesn't yet have a full automatic redirect in place, so http://www.reddit.com/r/gaming.json for example won't automatically redirect to the SSL/TLS https://www.reddit.com/r/gaming.json. This isn't a super-major thing, but it's a nice thing to use where possible. As far as I can see this change doesn't cause any problems, but you may wish to test it yourself, etc.

Feel free to tell me to go away if desired :wink:.
